### PR TITLE
Add prompt entity with CRUD operations

### DIFF
--- a/app/core/prompt/prompt.dynamo.ts
+++ b/app/core/prompt/prompt.dynamo.ts
@@ -1,0 +1,69 @@
+import { Entity } from 'electrodb'
+import { nanoid } from 'nanoid'
+import { Resource } from 'sst'
+import { getDynamoClient } from '~/clients/table.client'
+import { createFormattedDate, getTTL } from '~/utils'
+
+export const DynamoPrompt = () => {
+    const client = getDynamoClient()
+    const table = process.env.TABLE_NAME ?? Resource.Table.name
+
+    return new Entity(
+        {
+            model: {
+                entity: 'prompt',
+                version: '1',
+                service: 'prompt',
+            },
+            attributes: {
+                promptId: {
+                    type: 'string',
+                    required: true,
+                    default: () => nanoid().toLowerCase(),
+                },
+                content: {
+                    type: 'string',
+                    required: true,
+                },
+                userId: {
+                    type: 'string',
+                    required: false,
+                },
+                createdAt: {
+                    type: 'string',
+                    required: true,
+                    default: () => createFormattedDate(),
+                },
+                updatedAt: {
+                    type: 'string',
+                    required: true,
+                    default: () => createFormattedDate(),
+                },
+                expireAt: {
+                    type: 'number',
+                    required: false,
+                },
+                type: {
+                    type: 'string',
+                    required: true,
+                    default: () => 'prompt',
+                },
+            },
+            indexes: {
+                primary: {
+                    pk: { field: 'pk', composite: ['promptId'] },
+                    sk: { field: 'sk', composite: [] },
+                },
+                byUserId: {
+                    index: 'gsi1pk-gsi1sk-index',
+                    pk: { field: 'gsi1pk', composite: ['userId'] },
+                    sk: { field: 'gsi1sk', composite: ['createdAt'] },
+                },
+            },
+        },
+        {
+            client,
+            table,
+        },
+    )
+}

--- a/app/core/prompt/prompt.integration.test.ts
+++ b/app/core/prompt/prompt.integration.test.ts
@@ -1,0 +1,159 @@
+import { it, expect } from 'vitest'
+import { v4 } from 'uuid'
+
+const SERVER_URL = `http://localhost:${process.env.SERVER_PORT}`
+
+it('should be able to create and retrieve a prompt', async () => {
+    const createPromptArgs = {
+        content: 'This is a test prompt content',
+        userId: 'user123',
+    }
+
+    const returnedPromptId = await fetch(`${SERVER_URL}/createPrompt`, {
+        method: 'POST',
+        body: JSON.stringify(createPromptArgs),
+    })
+        .then((res) => res.json())
+        .then((data) => data.promptId)
+
+    const fetchedPrompt = await fetch(
+        `${SERVER_URL}/getPrompt?promptId=${returnedPromptId}`,
+        {
+            method: 'GET',
+        },
+    )
+        .then((response) => response.json())
+        .then((data) => data.prompt)
+
+    expect(returnedPromptId).toBeDefined()
+    expect(fetchedPrompt).toBeDefined()
+    expect(fetchedPrompt.promptId).toBe(returnedPromptId)
+    expect(fetchedPrompt.content).toBe('This is a test prompt content')
+    expect(fetchedPrompt.userId).toBe('user123')
+    expect(fetchedPrompt.createdAt).toBeDefined()
+    expect(fetchedPrompt.updatedAt).toBeDefined()
+})
+
+it('should still create a prompt if no userId is provided', async () => {
+    const createPromptArgs = {
+        content: 'Anonymous prompt content',
+    }
+
+    const returnedPromptId = await fetch(`${SERVER_URL}/createPrompt`, {
+        method: 'POST',
+        body: JSON.stringify(createPromptArgs),
+    })
+        .then((res) => res.json())
+        .then((data) => data.promptId)
+
+    expect(returnedPromptId).toBeDefined()
+})
+
+it('should update a prompt', async () => {
+    const createPromptArgs = {
+        content: 'Original prompt content',
+        userId: 'user123',
+    }
+
+    const createdPromptId = await fetch(`${SERVER_URL}/createPrompt`, {
+        method: 'POST',
+        body: JSON.stringify(createPromptArgs),
+    })
+        .then((response) => response.json())
+        .then((data) => data.promptId)
+
+    await fetch(`${SERVER_URL}/updatePrompt`, {
+        method: 'POST',
+        body: JSON.stringify({
+            promptId: createdPromptId,
+            updateFields: {
+                content: 'Updated prompt content',
+            },
+        }),
+    })
+
+    const updatedPrompt = await fetch(
+        `${SERVER_URL}/getPrompt?promptId=${createdPromptId}`,
+        {
+            method: 'GET',
+        },
+    )
+        .then((response) => response.json())
+        .then((data) => data.prompt)
+
+    expect(createdPromptId).toBeDefined()
+    expect(updatedPrompt.promptId).toBe(createdPromptId)
+    expect(updatedPrompt.content).toBe('Updated prompt content')
+    expect(updatedPrompt.userId).toBe('user123')
+})
+
+it('should fetch the asked-of amount of prompts for a specific user in descending order', async () => {
+    const userId = v4()
+    const prompts = [
+        {
+            content: 'First prompt',
+            userId,
+        },
+        {
+            content: 'Second prompt',
+            userId,
+        },
+        {
+            content: 'Third prompt',
+            userId,
+        },
+        {
+            content: 'Fourth prompt for different user',
+            userId: 'differentUser',
+        },
+    ]
+
+    for (const prompt of prompts) {
+        await fetch(`${SERVER_URL}/createPrompt`, {
+            method: 'POST',
+            body: JSON.stringify(prompt),
+        })
+    }
+
+    const userPrompts = await fetch(
+        `${SERVER_URL}/getUserPrompts?userId=${userId}&count=2`,
+        {
+            method: 'GET',
+        },
+    )
+        .then((response) => response.json())
+        .then((data) => data.prompts)
+
+    expect(userPrompts.length).toEqual(2)
+    expect(userPrompts.every((p: any) => p.userId === userId)).toBe(true)
+})
+
+it('should delete a prompt', async () => {
+    const createPromptArgs = {
+        content: 'Prompt to be deleted',
+        userId: 'user123',
+    }
+
+    const createdPromptId = await fetch(`${SERVER_URL}/createPrompt`, {
+        method: 'POST',
+        body: JSON.stringify(createPromptArgs),
+    })
+        .then((response) => response.json())
+        .then((data) => data.promptId)
+
+    await fetch(`${SERVER_URL}/deletePrompt`, {
+        method: 'DELETE',
+        body: JSON.stringify({
+            promptId: createdPromptId,
+        }),
+    })
+
+    const deletedPromptResponse = await fetch(
+        `${SERVER_URL}/getPrompt?promptId=${createdPromptId}`,
+        {
+            method: 'GET',
+        },
+    )
+
+    expect(deletedPromptResponse.status).toBe(404)
+})

--- a/app/core/prompt/prompt.model.ts
+++ b/app/core/prompt/prompt.model.ts
@@ -1,0 +1,18 @@
+import z from 'zod'
+
+export interface Prompt {
+    promptId: string
+    content: string
+    userId?: string
+    createdAt: string
+    updatedAt: string
+    expireAt?: number
+}
+
+export const PromptSchema = z.object({
+    promptId: z.string(),
+    content: z.string(),
+    userId: z.string().optional(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+})

--- a/app/core/prompt/prompt.service.ts
+++ b/app/core/prompt/prompt.service.ts
@@ -1,0 +1,49 @@
+import { DynamoPrompt } from './prompt.dynamo'
+import type { Prompt } from './prompt.model'
+import { createFormattedDate, getTTL } from '~/utils'
+
+const getPrompt = async (promptId: string) => {
+    const { data: prompt } = await DynamoPrompt().get({ promptId }).go()
+    return prompt
+}
+
+const getUserPrompts = async (userId: string, count?: number) => {
+    const { data: prompts } = await DynamoPrompt()
+        .query.byUserId({ userId })
+        .go({ order: 'desc', ...(count && { count }) })
+    return prompts
+}
+
+const createPrompt = async (
+    prompt: Pick<Prompt, 'content' | 'userId'>,
+) => {
+    const { data } = await DynamoPrompt()
+        .put({
+            ...prompt,
+            ...(process.env.CICD_WEB_URL && { expireAt: getTTL(1) }),
+        })
+        .go()
+    return data.promptId
+}
+
+const updatePrompt = async (promptId: string, promptFields: Partial<Prompt>) => {
+    await DynamoPrompt()
+        .patch({ promptId })
+        .set({
+            ...promptFields,
+            updatedAt: createFormattedDate(),
+        })
+        .go()
+}
+
+const deletePrompt = async (promptId: string) => {
+    await DynamoPrompt().delete({ promptId }).go()
+}
+
+export const promptService = {
+    getPrompt,
+    getUserPrompts,
+    createPrompt,
+    updatePrompt,
+    deletePrompt,
+}

--- a/app/server/main.ts
+++ b/app/server/main.ts
@@ -3,11 +3,13 @@ import { Hono } from 'hono'
 import { destinationRouter } from './routers/destination.router'
 import { tripRouter } from './routers/trip.router'
 import { analyticsRouter } from './routers/analytics.router'
+import { promptRouter } from './routers/prompt.router'
 
 const main = new Hono()
     .route('/', destinationRouter)
     .route('/', tripRouter)
     .route('/', analyticsRouter)
+    .route('/', promptRouter)
 export type AppType = typeof main
 
 export { main }

--- a/app/server/routers/prompt.router.test.ts
+++ b/app/server/routers/prompt.router.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest'
+import { testClient } from 'hono/testing'
+import { promptService } from '~/core/prompt/prompt.service'
+import { promptRouter } from './prompt.router'
+import { Hono } from 'hono'
+import type { Prompt } from '~/core/prompt/prompt.model'
+
+vi.mock('~/core/prompt/prompt.service.ts', () => ({
+    promptService: {
+        getPrompt: vi.fn(),
+        createPrompt: vi.fn(),
+        getUserPrompts: vi.fn(),
+        updatePrompt: vi.fn(),
+        deletePrompt: vi.fn(),
+    },
+}))
+
+vi.mock('../main', () => ({
+    main: new Hono().route('/', promptRouter),
+}))
+import { main } from '../main'
+
+describe('/createPrompt', () => {
+    it('should create a prompt and return its id', async () => {
+        const client = testClient(main)
+        const inputs = {
+            content: 'Test prompt content',
+            userId: 'user123',
+        }
+
+        vi.mocked(promptService.createPrompt).mockResolvedValue('prompt123')
+
+        const response = await client.createPrompt.$post({
+            json: inputs,
+        })
+
+        expect(response.status).toBe(200)
+        const responseBody = await response.json()
+        expect(responseBody).toEqual({ promptId: 'prompt123' })
+        expect(promptService.createPrompt).toHaveBeenCalledWith(inputs)
+    })
+
+    it('should create a prompt without userId', async () => {
+        const client = testClient(main)
+        const inputs = {
+            content: 'Anonymous prompt content',
+        }
+
+        vi.mocked(promptService.createPrompt).mockResolvedValue('prompt456')
+
+        const response = await client.createPrompt.$post({
+            json: inputs,
+        })
+
+        expect(response.status).toBe(200)
+        const responseBody = await response.json()
+        expect(responseBody).toEqual({ promptId: 'prompt456' })
+        expect(promptService.createPrompt).toHaveBeenCalledWith(inputs)
+    })
+})
+
+describe('/getPrompt', () => {
+    it('should get a prompt by id', async () => {
+        const client = testClient(main)
+        const mockPrompt: Prompt = {
+            promptId: 'prompt123',
+            content: 'Test prompt content',
+            userId: 'user123',
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:00Z',
+        }
+
+        vi.mocked(promptService.getPrompt).mockResolvedValue(mockPrompt)
+
+        const response = await client.getPrompt.$get({
+            query: { promptId: 'prompt123' },
+        })
+
+        expect(response.status).toBe(200)
+        const responseBody = await response.json()
+        expect(responseBody).toEqual({ prompt: mockPrompt })
+        expect(promptService.getPrompt).toHaveBeenCalledWith('prompt123')
+    })
+})
+
+describe('/getUserPrompts', () => {
+    it('should get user prompts', async () => {
+        const client = testClient(main)
+        const mockPrompts: Prompt[] = [
+            {
+                promptId: 'prompt1',
+                content: 'First prompt',
+                userId: 'user123',
+                createdAt: '2024-01-01T00:00:00Z',
+                updatedAt: '2024-01-01T00:00:00Z',
+            },
+            {
+                promptId: 'prompt2',
+                content: 'Second prompt',
+                userId: 'user123',
+                createdAt: '2024-01-02T00:00:00Z',
+                updatedAt: '2024-01-02T00:00:00Z',
+            },
+        ]
+
+        vi.mocked(promptService.getUserPrompts).mockResolvedValue(mockPrompts)
+
+        const response = await client.getUserPrompts.$get({
+            query: { userId: 'user123', count: '2' },
+        })
+
+        expect(response.status).toBe(200)
+        const responseBody = await response.json()
+        expect(responseBody).toEqual({ prompts: mockPrompts })
+        expect(promptService.getUserPrompts).toHaveBeenCalledWith('user123', 2)
+    })
+})
+
+describe('/updatePrompt', () => {
+    it('should update a prompt', async () => {
+        const client = testClient(main)
+        const updateData = {
+            promptId: 'prompt123',
+            updateFields: {
+                content: 'Updated content',
+            },
+        }
+
+        vi.mocked(promptService.updatePrompt).mockResolvedValue(undefined)
+
+        const response = await client.updatePrompt.$post({
+            json: updateData,
+        })
+
+        expect(response.status).toBe(200)
+        const responseBody = await response.json()
+        expect(responseBody).toEqual({ promptId: 'prompt123' })
+        expect(promptService.updatePrompt).toHaveBeenCalledWith(
+            'prompt123',
+            expect.objectContaining({
+                content: 'Updated content',
+                updatedAt: expect.any(String),
+            }),
+        )
+    })
+})
+
+describe('/deletePrompt', () => {
+    it('should delete a prompt', async () => {
+        const client = testClient(main)
+
+        vi.mocked(promptService.deletePrompt).mockResolvedValue(undefined)
+
+        const response = await client.deletePrompt.$delete({
+            json: { promptId: 'prompt123' },
+        })
+
+        expect(response.status).toBe(200)
+        const responseBody = await response.json()
+        expect(responseBody).toEqual({ success: true })
+        expect(promptService.deletePrompt).toHaveBeenCalledWith('prompt123')
+    })
+})

--- a/app/server/routers/prompt.router.ts
+++ b/app/server/routers/prompt.router.ts
@@ -1,0 +1,150 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { zValidator } from '@hono/zod-validator'
+import { promptService } from '~/core/prompt/prompt.service'
+import { createFormattedDate, handleAsync } from '~/utils'
+import { PromptSchema } from '~/core/prompt/prompt.model'
+import { HTTPException } from 'hono/http-exception'
+
+const updatablePromptFields = PromptSchema.pick({
+    content: true,
+    updatedAt: true,
+}).partial()
+
+const promptRouter = new Hono()
+    .get(
+        '/getPrompt',
+        zValidator(
+            'query',
+            z.object({
+                promptId: z.string(),
+            }),
+        ),
+        async (c) => {
+            const { promptId } = c.req.valid('query')
+            console.info('Invoked server.getPrompt with promptId:', promptId)
+
+            const [prompt, getPromptError] = await handleAsync(
+                promptService.getPrompt(promptId),
+            )
+            if (getPromptError) {
+                console.error(`Error getting prompt: ${getPromptError.message}`)
+                throw new HTTPException(404, { message: 'Prompt not found' })
+            }
+
+            return c.json({
+                prompt: prompt!,
+            })
+        },
+    )
+    .get(
+        '/getUserPrompts',
+        zValidator(
+            'query',
+            z.object({ userId: z.string(), count: z.string().optional() }),
+        ),
+        async (c) => {
+            const { userId, count } = c.req.valid('query')
+            console.info(
+                'Invoked server.getUserPrompts with userId:',
+                userId,
+                count,
+            )
+
+            const [prompts, getPromptsError] = await handleAsync(
+                promptService.getUserPrompts(userId, Number(count)),
+            )
+            if (getPromptsError) {
+                console.error(`Error getting prompts: ${getPromptsError.message}`)
+                throw new HTTPException(500, {
+                    message: getPromptsError.message,
+                })
+            }
+            return c.json({ prompts: prompts ?? [] })
+        },
+    )
+    .post(
+        '/createPrompt',
+        zValidator(
+            'json',
+            z.object({
+                content: z.string(),
+                userId: z.string().optional(),
+            }),
+        ),
+        async (c) => {
+            const inputs = c.req.valid('json')
+            console.info('Invoked server.createPrompt with inputs:', inputs)
+
+            const [promptId, createPromptError] = await handleAsync(
+                promptService.createPrompt(inputs),
+            )
+            if (createPromptError) {
+                console.error(`Error creating prompt: ${createPromptError.message}`)
+                throw new HTTPException(500, {
+                    message: createPromptError.message,
+                })
+            }
+
+            return c.json({ promptId })
+        },
+    )
+    .post(
+        '/updatePrompt',
+        zValidator(
+            'json',
+            z.object({
+                promptId: z.string(),
+                updateFields: updatablePromptFields,
+            }),
+        ),
+        async (c) => {
+            const { promptId, updateFields } = c.req.valid('json')
+            console.info(
+                `Invoked server.updatePrompt with promptId: ${promptId} and updates:`,
+                updateFields,
+            )
+
+            const [, updatePromptError] = await handleAsync(
+                promptService.updatePrompt(promptId, {
+                    ...updateFields,
+                    updatedAt: createFormattedDate(),
+                }),
+            )
+            if (updatePromptError) {
+                console.error(`Error updating prompt: ${updatePromptError.message}`)
+                throw new HTTPException(500, {
+                    message: updatePromptError.message,
+                })
+            }
+
+            return c.json({ promptId })
+        },
+    )
+    .delete(
+        '/deletePrompt',
+        zValidator(
+            'json',
+            z.object({
+                promptId: z.string(),
+            }),
+        ),
+        async (c) => {
+            const { promptId } = c.req.valid('json')
+            console.info('Invoked server.deletePrompt with promptId:', promptId)
+
+            const [, deletePromptError] = await handleAsync(
+                promptService.deletePrompt(promptId),
+            )
+            if (deletePromptError) {
+                console.error(`Error deleting prompt: ${deletePromptError.message}`)
+                throw new HTTPException(500, {
+                    message: deletePromptError.message,
+                })
+            }
+
+            return c.json({ success: true })
+        },
+    )
+
+export { promptRouter }


### PR DESCRIPTION
- Add prompt.model.ts with Prompt interface and Zod schema
- Add prompt.dynamo.ts with DynamoDB configuration
- Add prompt.service.ts with service wrapper methods
- Add prompt router with REST endpoints
- Add comprehensive integration and unit tests
- Register prompt router in main server

🤖 Generated with [Claude Code](https://claude.ai/code)